### PR TITLE
filenames wtih spaces, git log, git ls-tree

### DIFF
--- a/lib/git-parser.js
+++ b/lib/git-parser.js
@@ -359,6 +359,31 @@ exports.parseGitStashShow = function(text) {
   });
 }
 
+exports.parseLsTreeSimple = function(data) {
+  var result = [];
+
+  var parseLine = function(line) {
+    // Format: <mode> SP <type> SP <object> TAB <file>
+    var fields = line.split('\t', 1)[0].split(' ');
+    var filePath = line.split('\t', 2)[1];
+
+    obj = {};
+    obj.name = path.basename(filePath);
+    obj.mode = fields[0];
+    obj.type = fields[1];
+    obj.sha1 = fields[2];
+
+    result.push(obj);
+  }
+
+  data.split('\n').forEach(function(line) {
+    line = line.trim();
+    if (line) parseLine(line);
+  });
+
+  return result;
+}
+
 exports.parseLsTree = function(filterPath) {
   var parseLine = function(index, tree, line) {
     // Format: <mode> SP <type> SP <object> TAB <file>

--- a/rest-api.js
+++ b/rest-api.js
@@ -717,9 +717,26 @@ app.get(config.prefix + '/repo/:repo/commit/:commit',
 
 /* GET /repo/:repo/log
  * 
- * Response:
+ * Request:
  *   json: {
+ *     ("revRange": <git log's revision range>,)
  *   }
+ *
+ * Response:
+ *   json: [
+ *     ({
+ *       refs: [],
+ *       sha1: <commit sha1 hash string>,
+ *       parents: [ (<parent sha1 hash string>)* ],
+ *       authorName: <author name>,
+ *       authorEmail: <author email>',
+ *       authorDate: <author date>,
+ *       committerName: <committer name>,
+ *       committerEmail: <committer email>,
+ *       commitDate: <commit date>,
+ *       message: <commit message>
+ *     })*
+ *   ]
  * Error:
  *   json: { "error": <error> }
  */
@@ -732,7 +749,11 @@ app.get(config.prefix + '/repo/:repo/log',
 
   logger.info('log');
 
-  dgit('log  --decorate=full --pretty=fuller --all --parents', repoDir,
+  var flags = '';
+
+  if (req.body.revRange) flags = flags + ' ' + req.body.revRange;
+
+  dgit('log  --decorate=full --pretty=fuller --all --parents' + flags, repoDir,
     gitParser.parseGitLog).then(
       function (log) { res.status(200).json(log); },
       function (error) { res.status(400).json({ error: error }); }

--- a/rest-api.js
+++ b/rest-api.js
@@ -652,6 +652,12 @@ app.get(config.prefix + '/repo/:repo/show/*',
 /* GET /repo/:repo/ls-tree/<path>?rev=<revision>
  *  `rev` -- can be any legal revision
  * 
+ * Request:
+ *   json: {
+ *     ("t": <git ls-tree's -t>,)
+ *     ("r": <git ls-tree's -r>,)
+ *   }
+ *
  * Response:
  *   json: [
  *     ({
@@ -673,7 +679,11 @@ app.get(config.prefix + '/repo/:repo/ls-tree/*',
   var rev = req.git.file.rev || 'HEAD';
   var file = req.git.file.path;
 
-  dgit('ls-tree -tr ' + rev + ' "' + file + '"', repoDir, gitParser.parseLsTreeSimple)
+  var flags = '';
+  if (req.body.t) flags = flags + ' -t';
+  if (req.body.r) flags = flags + ' -r';
+
+  dgit('ls-tree' + flags + ' ' + rev + ' "' + file + '"', repoDir, gitParser.parseLsTreeSimple)
     .then(function (obj) {
 	if (!obj) return Q.reject('No such file ' + file + ' in ' + rev);
 	return obj;

--- a/test/use-cases.js
+++ b/test/use-cases.js
@@ -273,35 +273,6 @@ describe('use case:', function () {
       });
   });
 
-/* WIP
-
-   it('should be possible to ls-tree on existing file', function (done) {
-     agent
-       .get('/repo/test/ls-tree/a.txt')
-//       .expect('Content-Type', /json/)
-       .expect(200)
-       .end(function (err, res) {
-         if (err) throw err;
-         should.not.exist(res.body.error);
-         res.text.should.equal('{omg}');
-         done();
-       });
-   });
-
-   it('should be possible to ls-tree on non-existing file', function (done) {
-     agent
-       .get('/repo/test/ls-tree/inexistant.txt')
-       .expect('Content-Type', /json/)
-       .expect(200)
-       .end(function (err, res) {
-         if (err) throw err;
-         should.not.exist(res.body.error);
-         res.text.should.equal('{omg}');
-         done();
-       });
-   });
-*/
-
   it('should return error when committing with no message', function (done) {
     agent
       .post('/repo/test/commit')
@@ -343,6 +314,34 @@ describe('use case:', function () {
 	done();
       });
   });
+
+   it('should be possible to ls-tree on committed file', function (done) {
+     agent
+       .get('/repo/test/ls-tree/a.txt')
+       .expect('Content-Type', /json/)
+       .expect(200)
+       .end(function (err, res) {
+         if (err) throw err;
+         should.not.exist(res.body.error);
+         res.body.length.should.equal(1);
+         res.body[0].name.should.equal("a.txt");
+         res.body[0].type.should.equal("blob");
+         done();
+       });
+   });
+
+   it('should be possible to ls-tree on non-existing file', function (done) {
+     agent
+       .get('/repo/test/ls-tree/inexistant.txt')
+       .expect('Content-Type', /json/)
+       .expect(200)
+       .end(function (err, res) {
+         if (err) throw err;
+         should.not.exist(res.body.error);
+         res.body.length.should.equal(0);
+         done();
+       });
+   });
 
   it('should return a correct branch list', function (done) {
     agent
@@ -630,6 +629,33 @@ describe('use case:', function () {
 	res.body.parents[0].should.startWith(commitB);
 	res.body.message.should.eql('AAA -> a.txt, remove b.txt');
 	done();
+      });
+  });
+
+
+  it('should urldecode file names with spaces', function (done) {
+    var fn = 'a file with spaces.txt';
+    uploadFile(agent, 'test', fn, 'Content of file')
+      .expect(200)
+      .end(function (err, res) {
+        agent
+          .post('/repo/test/commit')
+          .send({ message: 'commit file with spaces in name' })
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function (err, res) {
+
+            agent
+              .get('/repo/test/ls-tree/' + fn)
+              .expect(200)
+              .end(function (err, res) {
+                if (err) throw err;
+                should.not.exist(res.body.error);
+                res.body.length.should.equal(1);
+                res.body[0].name.should.equal(fn);
+                done();
+              });
+          });
       });
   });
 

--- a/test/use-cases.js
+++ b/test/use-cases.js
@@ -518,6 +518,20 @@ describe('use case:', function () {
       });
   });
 
+  it('should be possible to read log of last commit alone', function (done) {
+    agent
+      .get('/repo/test/log')
+      .send({ revRange: -1 })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) throw err;
+        res.body.should.be.an.instanceOf(Array);
+        res.body.length.should.equal(1);
+        done();
+      });
+  });
+
   it('should be possible to see commit A details', function (done) {
     agent
       .get('/repo/test/commit/' + commitA)

--- a/test/use-cases.js
+++ b/test/use-cases.js
@@ -634,7 +634,7 @@ describe('use case:', function () {
 
 
   it('should urldecode file names with spaces', function (done) {
-    var fn = 'a file with spaces.txt';
+    var fn = 'folder name/a file with spaces.txt';
     uploadFile(agent, 'test', fn, 'Content of file')
       .expect(200)
       .end(function (err, res) {
@@ -652,8 +652,17 @@ describe('use case:', function () {
                 if (err) throw err;
                 should.not.exist(res.body.error);
                 res.body.length.should.equal(1);
-                res.body[0].name.should.equal(fn);
-                done();
+                res.body[0].name.should.equal(path.basename(fn));
+
+                agent
+                  .get('/repo/test/tree/' + fn)
+                  .expect(200)
+                  .end(function (err, res) {
+                    if (err) throw err;
+                    should.not.exist(res.body.error);
+                    res.text.should.equal('Content of file');
+                    done();
+                  });
               });
           });
       });


### PR DESCRIPTION
Hello. Here is a PR with:
- bug fix to handle filenames with spaces
- add feature of git log revision range
- bug fix for ls-tree (kind of a hack because I couldnt understand the original implementation)
- breaking change: -tr in ls-tree not default anymore <<< not sure if you're ok with this